### PR TITLE
Use variable in tasks

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -36,6 +36,7 @@ galaxy_info:
     - name: macOS
       version:
         - Sierra
+        - High Sierra
     - name: MacOSX
       versions:
         - 10.11

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   git_config:
     name:   user.signingKey
     scope:  global
-    value:  572528979443740F
+    value:  "{{ git_gpg.git.signing_key }}"
 
 - name: Configure gpg-agent
   blockinfile:


### PR DESCRIPTION
The variable defined in `defaults/main.yml` wasn't being used in the tasks.  This PR fixes that.

I also added a little to the metadata to say that this role supports macOS High Sierra, as well.